### PR TITLE
docs: fix contributing link and code of conduct wording

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 ## Our Pledge
 
 In the interest of fostering a safe and welcoming environment, we as
-the Periphery pledge to make participation in our project and
+Periphery pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity, gender expression,
 level of experience, education, socio-economic status, nationality, personal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ As a contributor, here are the guidelines we would like you to follow:
 ## <a name="coc"></a> Code of Conduct
 
 Help us keep Edgewalker open and inclusive.
-Please read and follow our [Code of Conduct][CODE_OF_CONDUCT.md].
+Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## <a name="question"></a> Got a Question or Problem?
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/periphery-security/edgewalker/blob/main/docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The Code of Conduct says "we as the Periphery" and the Contributing page has a broken link to the code of conduct. 

Issue Number: N/A

## What is the new behavior?

Wording corrected and link is working.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information