### PR TITLE
ci: add missing headerPatternCorrespondence to commit lint workflow

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -47,6 +47,7 @@ jobs:
           # If the PR title contains a breaking change, it must be indicated by a `!`
           # before the colon. (optional)
           headerPattern: '^(\w+)(\(([\w\$\.\-\* ]+)\))?(!?): (.*)$'
+          headerPatternCorrespondence: type, scope, breaking, subject
           headerPatternError: |
             The PR title does not match the Conventional Commits spec.
             Example: "feat(ui): add new button"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/periphery-security/edgewalker/blob/main/docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The commit lint workflow has a custom headerPattern but is missing headerPatternCorrespondence, causing PR title validation to fail with "No subject found" even for valid titles.               

Issue Number: N/A

## What is the new behavior?

PR title validation correctly parses the subject from conventional commit titles.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
