### PR TITLE
Replace IoT with edge in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <img src="images/periphery_icon.png" alt="perihery-logo" width="120px" height="120px"/>
   <br>
-  <em>EdgeWalker is a high-performance IoT security scanner that audits your home network for open ports, default credentials, and known vulnerabilities. Developed by <a href="https://periphery.security">periphery</a>), it empowers users to verify the security claims of their smart devices rather than relying on marketing labels.</em>
+  <em>EdgeWalker is a high-performance edge security scanner that audits your home network for open ports, default credentials, and known vulnerabilities. Developed by <a href="https://periphery.security">periphery</a>), it empowers users to verify the security claims of their smart devices rather than relying on marketing labels.</em>
   <br>
 </p>
 
@@ -45,7 +45,7 @@
 | :--- | :--- | :--- |
 | **Port Scan** | Identifies open ports and active services. | `nmap` wrapper with parallel batch scanning. |
 | **Device Discovery** | Enhanced fingerprinting for accurate identification. | mDNS/Bonjour, UPnP/SSDP, and HTTP metadata scraping. |
-| **Credential Test** | Checks for default/weak passwords (SSH, FTP, Telnet, SMB). | Bundled database of ~430 common IoT credentials. |
+| **Credential Test** | Checks for default/weak passwords (SSH, FTP, Telnet, SMB). | Bundled database of ~430 common default credentials. |
 | **CVE Check** | Matches detected software against known vulnerabilities. | Real-time NVD API lookup. |
 | **Risk Scoring** | Provides an actionable security grade (A-F). | Proprietary scoring engine (0-100). |
 
@@ -107,7 +107,7 @@ See the [Configuration Guide](docs/configuration.md#non-interactive-silent-mode)
 
 ## The Periphery Mission
 
-We frequently encounter vendors who promise "secure by design" devices. We don't buy it. EdgeWalker began at **Periphery's 2025 Hackathon**, built in 48 hours by Dr Lina Anaya, Travis Pell, Steven Marks, and Adam Massey. It represents our commitment to transparency and evidence-based security in the IoT era.
+We frequently encounter vendors who promise "secure by design" devices. We don't buy it. EdgeWalker began at **Periphery's 2025 Hackathon**, built in 48 hours by Dr Lina Anaya, Travis Pell, Steven Marks, and Adam Massey. It represents our commitment to transparency and evidence-based security at the edge.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ Environment variables prefixed with `EW_` override all settings. `edgewalker/con
 | Variable | Default | Description |
 |---|---|---|
 | `EW_THEME` | `periphery` | Active UI theme slug |
-| `EW_IOT_PORTS` | `[21, 22, ...]` | Common IoT ports for quick scan |
+| `EW_IOT_PORTS` | `[21, 22, ...]` | Common edge ports for quick scan |
 | `EW_TELEMETRY_ENABLED` | `None` | User opt-in status for anonymous data sharing |
 | `EW_SILENT_MODE` | `False` | Run in non-interactive mode (bypass prompts) |
 | `EW_SUPPRESS_WARNINGS` | `False` | Suppress configuration and security warnings in the console |

--- a/docs/data-privacy.md
+++ b/docs/data-privacy.md
@@ -46,11 +46,11 @@ Before any data leaves your machine, `telemetry.py` processes it:
 
 ### Why We Collect This
 
-This data helps us understand IoT vulnerabilities at scale:
+This data helps us understand edge device vulnerabilities at scale:
 
 - Which default credentials appear most commonly in the wild
 - Which device types suffer exposure most frequently
-- Emerging vulnerability trends across consumer IoT
+- Emerging vulnerability trends across consumer edge devices
 
 The findings feed back into improving EdgeWalker's credential database and informing Periphery's security research.
 

--- a/docs/modules/password-scan.md
+++ b/docs/modules/password-scan.md
@@ -8,7 +8,7 @@ Tests default and weak credentials against SSH, FTP, Telnet, and SMB services fo
 
 EdgeWalker stores credentials locally in `edgewalker/data/creds.csv` — a plain CSV file you can inspect, edit, or extend. No network calls occur when loading credentials.
 
-The database contains ~430 entries sourced from known IoT default credentials:
+The database contains ~430 entries sourced from known default credentials:
 
 | Service | Entries | Examples |
 |---|---|---|

--- a/docs/modules/port-scan.md
+++ b/docs/modules/port-scan.md
@@ -6,7 +6,7 @@ Wraps `nmap` to discover devices and open ports on a network. Supports two scan 
 
 ## Quick Scan (~30 seconds)
 
-Scans 28 common IoT ports per host:
+Scans 28 common edge device ports per host:
 
 | Port | Service | Why |
 |---|---|---|
@@ -15,7 +15,7 @@ Scans 28 common IoT ports per host:
 | 23, 2323 | Telnet | Unencrypted remote access (Mirai target) |
 | 80, 81, 443, 8080, 8081, 8443 | HTTP/HTTPS | Web interfaces |
 | 554 | RTSP | Camera video streams |
-| 1883, 8883 | MQTT | IoT messaging protocol |
+| 1883, 8883 | MQTT | device messaging protocol |
 | 502 | Modbus | Industrial/EV charger protocol |
 | 5900 | VNC | Remote desktop |
 | 37777, 34567 | Camera | Dahua / Chinese DVR ports |
@@ -30,7 +30,7 @@ Scans 28 common IoT ports per host:
 
 Steps:
 1. Ping sweep to discover live hosts
-2. Parallel port scan of IoT ports per host
+2. Parallel port scan of edge ports per host
 3. Service version detection on open ports
 
 ## Full Scan (~15 minutes+)


### PR DESCRIPTION
Rebrands IoT references to edge across README and documentation. No code changes.